### PR TITLE
rotate toggle buttons when sidebars collapsed

### DIFF
--- a/packages/starlight-fullview-mode/styles/global.css
+++ b/packages/starlight-fullview-mode/styles/global.css
@@ -8,6 +8,15 @@
   cursor: pointer;
 }
 
+.main-side-bar-collapsed .toggle-left-side-bar-btn,
+.right-side-bar-collapsed .toggle-right-side-bar-btn{
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 :root {
   --tablet-navbar-inset-inline-start: 50px;
 }


### PR DESCRIPTION
This change will rotate the left and right toggle icons when the sidebar is collapsed

<img width="668" height="298" alt="image" src="https://github.com/user-attachments/assets/c8d6d56e-48a9-4a05-9c69-d855816ebc80" />

<img width="792" height="474" alt="image" src="https://github.com/user-attachments/assets/fd3d8316-9437-46c2-b90a-c8be069466f2" />


<img width="810" height="232" alt="image" src="https://github.com/user-attachments/assets/c8ec0333-4580-4987-8f9c-7b8b3f364a70" />
<img width="432" height="210" alt="image" src="https://github.com/user-attachments/assets/75ed7099-3c1b-4ba6-bcf7-7e1a7f7b63d1" />
